### PR TITLE
feat(observability): configure Alertmanager Discord notifications

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-discord-webhook
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: alertmanager-discord-webhook-secret
+    template:
+      data:
+        webhook-url: "{{ .ALERTMANAGER_DISCORD_WEBHOOK_URL }}"
+  dataFrom:
+    - extract:
+        key: alertmanager

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -46,8 +46,52 @@ spec:
             - name: internal
               namespace: kube-system
               sectionName: https
+      config:
+        global:
+          resolve_timeout: 5m
+        route:
+          receiver: discord
+          group_by: ["namespace", "alertname"]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          routes:
+            - receiver: "null"
+              matchers:
+                - alertname = Watchdog
+            - receiver: discord
+              matchers:
+                - severity =~ "critical|warning"
+              continue: true
+        receivers:
+          - name: "null"
+          - name: discord
+            slack_configs:
+              - send_resolved: true
+                api_url_file: /etc/alertmanager/secrets/alertmanager-discord-webhook-secret/webhook-url
+                channel: "#alerts"
+                title: |-
+                  [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+                text: >-
+                  {{ range .Alerts }}
+                    *Alert:* {{ .Labels.alertname }} - {{ .Labels.severity }}
+
+                    *Description:* {{ if .Annotations.description }}{{ .Annotations.description }}{{ else }}{{ .Annotations.summary }}{{ end }}
+
+                    *Details:*
+                    {{ range .Labels.SortedPairs }} - *{{ .Name }}:* {{ .Value }}
+                    {{ end }}
+                  {{ end }}
+        inhibit_rules:
+          - source_matchers:
+              - severity = critical
+            target_matchers:
+              - severity = warning
+            equal: ["namespace", "alertname"]
       alertmanagerSpec:
         externalUrl: https://alertmanager.npmulder.dev
+        secrets:
+          - alertmanager-discord-webhook-secret
         storage:
           volumeClaimTemplate:
             spec:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
           routes:
             - receiver: "null"
               matchers:
-                - alertname = Watchdog
+                - alertname = "Watchdog"
             - receiver: discord
               matchers:
                 - severity =~ "critical|warning"
@@ -84,9 +84,9 @@ spec:
                   {{ end }}
         inhibit_rules:
           - source_matchers:
-              - severity = critical
+              - severity = "critical"
             target_matchers:
-              - severity = warning
+              - severity = "warning"
             equal: ["namespace", "alertname"]
       alertmanagerSpec:
         externalUrl: https://alertmanager.npmulder.dev

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./scrapeconfig.yaml


### PR DESCRIPTION
## Summary

- Configure Alertmanager to deliver alerts to Discord via Slack-compatible webhook
- Add ExternalSecret for Discord webhook URL (sourced from OnePassword `alertmanager` item)
- Route critical/warning alerts to Discord, silence Watchdog, add severity-based inhibition
- Mount webhook secret securely via `alertmanagerSpec.secrets` + `api_url_file`

## Setup Required

1. Create a Discord webhook in the desired alerts channel
2. Store the webhook URL (with `/slack` suffix) in OnePassword:
   - Vault: `HomeLab`
   - Item: `alertmanager`
   - Field: `ALERTMANAGER_DISCORD_WEBHOOK_URL`
   - Value: `https://discord.com/api/webhooks/{id}/{token}/slack`

## Alert Routing

| Alerts | Receiver | Behavior |
|--------|----------|----------|
| Watchdog | null | Silenced (heartbeat-only) |
| severity=critical/warning | discord | Grouped by namespace+alertname, 12h repeat |
| All others | discord (default) | Default receiver |

## Test plan

- [ ] Create OnePassword item with Discord webhook URL
- [ ] Merge PR and verify Flux reconciles kube-prometheus-stack
- [ ] Confirm ExternalSecret syncs to `alertmanager-discord-webhook-secret`
- [ ] Check Alertmanager UI at alertmanager.npmulder.dev for updated config
- [ ] Verify firing alerts appear in Discord channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Alertmanager routing/notification behavior and introduces a new secret flow; misconfiguration could drop or spam alerts, but scope is limited to observability config.
> 
> **Overview**
> Configures `kube-prometheus-stack` Alertmanager to send notifications to Discord via a Slack-compatible webhook, including grouping/repeat behavior, a custom message template, silencing `Watchdog`, and a critical->warning inhibition rule.
> 
> Adds an `ExternalSecret` that pulls `ALERTMANAGER_DISCORD_WEBHOOK_URL` from the `onepassword-connect` `ClusterSecretStore` into `alertmanager-discord-webhook-secret`, mounts it via `alertmanagerSpec.secrets`, and references it with `api_url_file` in the receiver config; updates `kustomization.yaml` to include the new resource.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7904697584391d1934ac8ead1b6338052090383. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->