### PR TITLE
feat(observability): add network infrastructure probes

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
@@ -12,3 +12,40 @@ spec:
     staticConfig:
       static:
         - truenas.internal:2049
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: network-icmp
+spec:
+  interval: 1m
+  module: icmp
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        probe_group: network-infrastructure
+      static:
+        - 10.1.2.1   # UDR7 router / default gateway
+        - 10.1.2.5   # Pi-hole DNS
+        - 10.1.2.11  # TrueNAS storage
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: network-tcp
+spec:
+  interval: 1m
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        probe_group: network-infrastructure
+      static:
+        - 10.1.2.22:443  # Internal ingress (HTTPS)
+        - 10.1.2.21:443  # External ingress / CF Tunnel (HTTPS)


### PR DESCRIPTION
## Summary

- Add ICMP ping probes for core network devices: UDR7 router (10.1.2.1), Pi-hole DNS (10.1.2.5), TrueNAS storage (10.1.2.11)
- Add TCP connect probes for ingress endpoints: internal ingress (10.1.2.22:443), external/CF Tunnel ingress (10.1.2.21:443)
- Probes run every 1m via blackbox exporter, auto-discovered by Prometheus
- Existing `BlackboxProbeFailed` alert fires after 15m of probe failure

## Changes

File: `kubernetes/apps/observability/blackbox-exporter/app/probes.yaml`
- Added `network-icmp` Probe CRD (icmp module, 3 targets)
- Added `network-tcp` Probe CRD (tcp_connect module, 2 targets)
- Both labeled `probe_group: network-infrastructure` for filtering

## Test plan

- [ ] Flux reconciles the new Probe CRDs without errors
- [ ] Prometheus discovers the new probe targets (check /targets)
- [ ] Blackbox exporter successfully probes all 5 targets (probe_success == 1)
- [ ] Grafana can query probe metrics with `{probe_group="network-infrastructure"}`

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that adds new blackbox Probe targets; main impact is potential additional alert noise if the new endpoints are flaky or misconfigured.
> 
> **Overview**
> Adds two new Prometheus `Probe` CRDs in `blackbox-exporter/app/probes.yaml` to monitor network infrastructure via blackbox exporter.
> 
> Introduces a 1-minute ICMP probe for core devices and a 1-minute TCP connect probe for ingress HTTPS endpoints, both labeled with `probe_group: network-infrastructure` for filtering/alerting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ffec243a9b9f87661ada24daaa25777058abff1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->