### PR TITLE
fix(recyclarr): migrate config to v8 format

### DIFF
--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -52,3 +52,11 @@ radarr:
             - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
             - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
             - f537cf427b64c38c8e36298f657e4828 # Scene
+
+    # Score override: neutralize x265 (no HDR/DV) penalty on SQP-1 (2160p)
+    custom_formats:
+      - trash_ids:
+          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        assign_scores_to:
+          - trash_id: 5128baeb2b081b72126bc8482b2a86a0 # SQP-1 (2160p)
+            score: 0

--- a/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/default/recyclarr/app/resources/recyclarr.yml
@@ -1,51 +1,54 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+
+# Migrated to recyclarr v8 format (include templates removed in v8)
+
 sonarr:
   sonarr:
     base_url: http://sonarr.default.svc.cluster.local
     api_key: !env_var SONARR_API_KEY
-    delete_old_custom_formats: true
-    replace_existing_custom_formats: true
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
+
+    quality_definition:
+      type: series
+
     quality_profiles:
-      - name: WEB-1080p
-    custom_formats:
-      - trash_ids:
-          - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
-          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
-          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
-          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
-        assign_scores_to:
-          - name: WEB-1080p
+      - trash_id: 72dae194fc92bf828f32cde7744e51a1 # WEB-1080p
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      add:
+        - trash_id: 158188097a58d7687dee647e04af0da3 # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
+        - trash_id: f4a0410a1df109a66d6e47dcadcce014 # [Optional] Miscellaneous
+          select:
+            - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
+            - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
+            - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
+            - 06d66ab109d4d2eddb2794d21526d140 # Retags
+            - 1b3994c551cbb92a2c781af061f4ab44 # Scene
 
 radarr:
   radarr:
     base_url: http://radarr.default.svc.cluster.local
     api_key: !env_var RADARR_API_KEY
-    delete_old_custom_formats: true
-    replace_existing_custom_formats: true
+
+    quality_definition:
+      type: sqp-streaming
+
     quality_profiles:
-      - name: SQP-1 (2160p)
-    include:
-      - template: radarr-quality-definition-sqp-streaming
-      - template: radarr-quality-profile-sqp-1-2160p-default
-      - template: radarr-custom-formats-sqp-1-2160p
-    custom_formats:
-      - trash_ids:
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-        assign_scores_to:
-          - name: SQP-1 (2160p)
-            score: 0
-      - trash_ids:
-          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-          - f537cf427b64c38c8e36298f657e4828 # Scene
-        assign_scores_to:
-          - name: SQP-1 (2160p)
+      - trash_id: 5128baeb2b081b72126bc8482b2a86a0 # SQP-1 (2160p)
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      add:
+        - trash_id: 9337080378236ce4c0b183e35790d2a7 # [Optional] Miscellaneous
+          select:
+            - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+            - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
+            - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
+            - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
+            - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
+            - f537cf427b64c38c8e36298f657e4828 # Scene


### PR DESCRIPTION
## Summary
- Migrates recyclarr config from v7 include-template format to v8 inline format
- Fixes `Fatal error: Unable to find include template radarr-quality-definition-sqp-streaming` caused by the 7.4.1 → 8.5.1 image bump (#385)
- Preserves all existing custom format selections (Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene, Black and White Editions)

## Changes
- Replace `include:` template references with `quality_definition:` type declarations
- Use guide-backed `quality_profiles` with `trash_id` instead of name-based profiles
- Convert `custom_formats` to `custom_format_groups` with `add:`/`select:` syntax
- Replace `delete_old_custom_formats`/`replace_existing_custom_formats` with `reset_unmatched_scores`
- Update YAML schema reference to v8

## Test plan
- [ ] Verify recyclarr CronJob completes successfully after merge
- [ ] Confirm Sonarr quality profile and custom formats are synced correctly
- [ ] Confirm Radarr SQP-1 (2160p) quality profile and custom formats are synced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)